### PR TITLE
Update to use the latest IPMIView tool (2.18.0)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV DISPLAY=:0.0
 
 ADD supervisord.conf /etc/supervisor/conf.d/supervisord.conf
-ADD IPMIView_2.17.0_build.200505_bundleJRE_Linux_x64 /opt/IPMIView
+ADD IPMIView_2.18.0_build.201007_bundleJRE_Linux_x64 /opt/IPMIView
 
 RUN apt-get update
 RUN apt-get dist-upgrade -y --no-install-recommends

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ This container runs:
 ## Usage
 
 ```bash
-wget https://www.supermicro.com/wftp/utility/IPMIView/Linux/IPMIView_2.17.0_build.200505_bundleJRE_Linux_x64.tar.gz
-tar zxvf IPMIView_2.17.0_build.200505_bundleJRE_Linux_x64.tar.gz
+wget https://www.supermicro.com/wdl/utility/IPMIView/Linux/IPMIView_2.18.0_build.201007_bundleJRE_Linux_x64.tar.gz
+tar zxvf IPMIView_2.18.0_build.201007_bundleJRE_Linux_x64.tar.gz
 make
 docker run -p 8080:8080 sunfoxcz/ipmiview:latest
 ```


### PR DESCRIPTION
Download URL for 2.17.0 does not work. Updated to use 2.18.0.