### PR TITLE
update launch.sh to current novnc_proxy script

### DIFF
--- a/supervisord.conf
+++ b/supervisord.conf
@@ -10,7 +10,7 @@ command=/usr/bin/x11vnc
 autorestart=true
 
 [program:noVNC]
-command=/opt/noVNC/utils/launch.sh --vnc localhost:5900 --listen 8080
+command=/opt/noVNC/utils/novnc_proxy --vnc localhost:5900 --listen 8080
 autorestart=true
 
 [program:fluxbox]


### PR DESCRIPTION
The `launch.sh` script no longer exists in the noVNC utils directory and has been replaced with the `novnc_proxy` script. Usage referenced here: https://github.com/novnc/noVNC#quick-start